### PR TITLE
Add requirements file and simplify install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ git clone https://github.com/2wenty2wo/pi-dvd-screensaver.git
 
 2. Install the required dependencies:
 ```shell
-pip install adafruit-circuitpython-ssd1306
-pip install RPi.GPIO
+pip install -r requirements.txt
 ```
 
 3. Connect the Adafruit 128x64 OLED Bonnet to your Raspberry Pi.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+adafruit-circuitpython-ssd1306
+RPi.GPIO
+Pillow


### PR DESCRIPTION
## Summary
- add `requirements.txt` with python dependencies
- update install instructions to use the requirements file

## Testing
- `python -m py_compile pi-dvd-screensaver.py`

------
https://chatgpt.com/codex/tasks/task_e_68402f373b808329b1126da0ef7278ef